### PR TITLE
Fix to connection time out when downloading

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
+  config.vm.box = "hashicorp/precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
   config.vm.network :forwarded_port, guest: 3306, host: 3306
   config.vm.provision :shell, :path => "install.sh"


### PR DESCRIPTION
when the box is set to precise64 it can not download the box, new box name added.
error looks like:
```
    default: Downloading: http://files.vagrantup.com/precise64.box
    default: Download redirected to host: hashicorp-files.hashicorp.com
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

Failed to connect to hashicorp-files.hashicorp.com port 443: Operation timed out
```
but now it will actually download at proceed on Mac OS Mojave